### PR TITLE
Fix default API base URL

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import TestCaseManager from './components/TestCaseManager';
 import HarAnalyzer from './components/HarAnalyzer';
 import ResultsDashboard from './components/ResultsDashboard';
 import { FileText, Upload, BarChart3, Settings } from 'lucide-react';
+import { BACKEND_URL } from './config';
 
 const App = () => {
   const [activeTab, setActiveTab] = useState('test-cases');
@@ -23,7 +24,7 @@ const App = () => {
 
   const fetchTestCases = async () => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/test-cases`);
+      const response = await fetch(`${BACKEND_URL}/api/test-cases`);
       const data = await response.json();
       setTestCases(data.test_cases || []);
     } catch (error) {

--- a/frontend/src/components/HarAnalyzer.js
+++ b/frontend/src/components/HarAnalyzer.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Upload, FileText, Play, CheckCircle, XCircle, Folder, Clock } from 'lucide-react';
+import { BACKEND_URL } from '../config';
 
 const HarAnalyzer = ({ onAnalysisComplete }) => {
   const [file, setFile] = useState(null);
@@ -17,7 +18,7 @@ const HarAnalyzer = ({ onAnalysisComplete }) => {
 
   const fetchAvailableHarFiles = async () => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/har-files`);
+      const response = await fetch(`${BACKEND_URL}/api/har-files`);
       const data = await response.json();
       setAvailableHarFiles(data.har_files || []);
     } catch (error) {
@@ -77,7 +78,7 @@ const HarAnalyzer = ({ onAnalysisComplete }) => {
       
       if (selectedHarFile) {
         // Analyze existing HAR file
-        response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/analyze-har-file/${selectedHarFile.filename}`, {
+        response = await fetch(`${BACKEND_URL}/api/analyze-har-file/${selectedHarFile.filename}`, {
           method: 'POST',
         });
       } else {
@@ -85,7 +86,7 @@ const HarAnalyzer = ({ onAnalysisComplete }) => {
         const formData = new FormData();
         formData.append('file', file);
 
-        response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/analyze-har`, {
+        response = await fetch(`${BACKEND_URL}/api/analyze-har`, {
           method: 'POST',
           body: formData,
         });

--- a/frontend/src/components/ResultsDashboard.js
+++ b/frontend/src/components/ResultsDashboard.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { 
   Download, 
+import { BACKEND_URL } from '../config';
   CheckCircle, 
   XCircle, 
   AlertCircle, 
@@ -35,7 +36,7 @@ const ResultsDashboard = ({ report }) => {
   const handleExportReport = async () => {
     try {
       // This would need the report ID from the backend
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/reports/export`, {
+      const response = await fetch(`${BACKEND_URL}/api/reports/export`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(report)

--- a/frontend/src/components/TestCaseManager.js
+++ b/frontend/src/components/TestCaseManager.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Plus, Edit, Trash2, Save, X } from 'lucide-react';
+import { BACKEND_URL } from '../config';
 
 const TestCaseManager = ({ testCases, onTestCasesUpdate }) => {
   const [isEditing, setIsEditing] = useState(false);
@@ -50,7 +51,7 @@ const TestCaseManager = ({ testCases, onTestCasesUpdate }) => {
       
       if (editingCase) {
         // Update existing test case
-        const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/test-cases/${editingCase.id}`, {
+        const response = await fetch(`${BACKEND_URL}/api/test-cases/${editingCase.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ ...testCase, id: editingCase.id })
@@ -61,7 +62,7 @@ const TestCaseManager = ({ testCases, onTestCasesUpdate }) => {
         }
       } else {
         // Create new test case
-        const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/test-cases`, {
+        const response = await fetch(`${BACKEND_URL}/api/test-cases`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(testCase)
@@ -102,7 +103,7 @@ const TestCaseManager = ({ testCases, onTestCasesUpdate }) => {
   const handleDelete = async (testCaseId) => {
     if (window.confirm('CONFIRM DELETION OF TEST CASE?')) {
       try {
-        const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/test-cases/${testCaseId}`, {
+        const response = await fetch(`${BACKEND_URL}/api/test-cases/${testCaseId}`, {
           method: 'DELETE'
         });
         

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,1 @@
+export const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || '';


### PR DESCRIPTION
## Summary
- provide default BACKEND_URL constant in React frontend
- use BACKEND_URL for all API requests

## Testing
- `python3 system-check.py`
- `python3 test-system.py` *(fails: Backend API not accessible)*

------
https://chatgpt.com/codex/tasks/task_e_687e9e89cb6083238d8cb886378512e9