### PR TITLE
Fix ResultsDashboard import syntax

### DIFF
--- a/frontend/src/components/ResultsDashboard.js
+++ b/frontend/src/components/ResultsDashboard.js
@@ -1,15 +1,15 @@
 import React, { useState } from 'react';
-import { 
-  Download, 
-import { BACKEND_URL } from '../config';
-  CheckCircle, 
-  XCircle, 
-  AlertCircle, 
-  BarChart3, 
-  FileText, 
+import {
+  Download,
+  CheckCircle,
+  XCircle,
+  AlertCircle,
+  BarChart3,
+  FileText,
   Globe,
   Settings
 } from 'lucide-react';
+import { BACKEND_URL } from '../config';
 
 const ResultsDashboard = ({ report }) => {
   const [activeView, setActiveView] = useState('summary');


### PR DESCRIPTION
## Summary
- fix incorrect import statement in `ResultsDashboard.js`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687ea2657fe883238a42873d3ea9877b