### PR TITLE
Improve test group interface and reporting

### DIFF
--- a/frontend/src/components/ResultsDashboard.js
+++ b/frontend/src/components/ResultsDashboard.js
@@ -194,13 +194,15 @@ const ResultsDashboard = ({ report }) => {
                   <tr>
                     <th>GROUP</th>
                     <th>PASS</th>
+                    <th>MESSAGE</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {Object.entries(report.group_results).map(([name, passed]) => (
+                  {Object.entries(report.group_results).map(([name, data]) => (
                     <tr key={name}>
                       <td>{name}</td>
-                      <td>{passed ? 'YES' : 'NO'}</td>
+                      <td>{data.passed ? 'YES' : 'NO'}</td>
+                      <td>{data.message}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/test_groups.json
+++ b/test_groups.json
@@ -2,6 +2,8 @@
   {
     "id": "group-1",
     "name": "Basic Sequence",
-    "sequence": ["App Build Parameter Check", "API Version Validation", "User Agent Detection"]
+    "sequence": ["App Build Parameter Check", "API Version Validation", "User Agent Detection"],
+    "on_pass_message": "Basic Sequence completed successfully",
+    "on_fail_message": "Basic Sequence failed"
   }
 ]


### PR DESCRIPTION
## Summary
- add configurable pass/fail messages to `TestGroup`
- include group test results in analysis output
- extend Excel export with group results
- allow building group sequences through selectable tests in the UI
- display group messages in the dashboard table
- update default `test_groups.json`

## Testing
- `python -m py_compile backend/server.py`
- `python test-system.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688a9ddc271483239069583b3def4ddf