### PR TITLE
Add feature section to homepage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import HarAnalyzer from './components/HarAnalyzer';
 import ResultsDashboard from './components/ResultsDashboard';
 import { FileText, Upload, BarChart3, Settings, Layers } from 'lucide-react';
 import { BACKEND_URL } from './config';
+import { Feature16 } from './components/Feature16';
 
 const App = () => {
   const [activeTab, setActiveTab] = useState('test-cases');
@@ -102,6 +103,7 @@ const App = () => {
       </nav>
 
       <main className="app-main">
+        <Feature16 />
         <div className="main-content">
           {renderContent()}
         </div>

--- a/frontend/src/components/Feature16.js
+++ b/frontend/src/components/Feature16.js
@@ -1,0 +1,48 @@
+import { Timer, Zap, ZoomIn } from "lucide-react";
+
+const Feature16 = () => {
+  return (
+    <section className="py-32">
+      <div className="container">
+        <h2 className="text-3xl font-medium lg:text-4xl">
+          Get real-time alerts and dashboard snapshots—fix staffing, menu, and flow issues before they cost you.
+        </h2>
+        <div className="mt-14 grid gap-6 lg:mt-20 lg:grid-cols-3">
+          <div className="rounded-lg bg-accent p-5">
+            <span className="mb-8 flex size-12 items-center justify-center rounded-full bg-background">
+              <Timer className="size-6" />
+            </span>
+            <h3 className="mb-2 text-xl font-medium">Still running your nights blind?</h3>
+            <p className="leading-7 text-muted-foreground">
+              Stay ahead with instant insights into floor performance.
+            </p>
+          </div>
+          <div className="rounded-lg bg-accent p-5">
+            <span className="mb-8 flex size-12 items-center justify-center rounded-full bg-background">
+              <ZoomIn className="size-6" />
+            </span>
+            <h3 className="mb-2 text-xl font-medium">Empty tables after rush?</h3>
+            <p className="leading-7 text-muted-foreground">
+              Spot traffic dips and act fast to fill your seats.
+            </p>
+          </div>
+          <div className="rounded-lg bg-accent p-5">
+            <span className="mb-8 flex size-12 items-center justify-center rounded-full bg-background">
+              <Zap className="size-6" />
+            </span>
+            <h3 className="mb-2 text-xl font-medium">Unbalanced staff scheduling?</h3>
+            <p className="leading-7 text-muted-foreground">
+              Optimize staffing to match demand and avoid burnout.
+            </p>
+          </div>
+        </div>
+        <ul className="mt-8 list-disc pl-5 text-muted-foreground">
+          <li>Dish waste or unpopular menu items?</li>
+          <li>Poor reviews from slow service?</li>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export { Feature16 };


### PR DESCRIPTION
## Summary
- Add Feature16 component highlighting operational pain points and solutions
- Show new feature section on homepage before existing dashboard content

## Testing
- `npm test -- --watchAll=false` (fails: No tests found)
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_6892e95658648323a3a97779a6d46563