### PR TITLE
feat: add Charles session parser and ingest endpoint

### DIFF
--- a/backend/parsers/chlsj_parser.py
+++ b/backend/parsers/chlsj_parser.py
@@ -1,0 +1,48 @@
+import json
+from typing import List, Dict, Any, IO
+
+
+def parse_chlsj(file_obj: IO) -> List[Dict[str, Any]]:
+    """Parse a Charles .chlsj session file into a list of network events.
+
+    The returned structure roughly matches the NetworkEvent schema used
+    elsewhere in Harmony.  Only a subset of fields are extracted; unknown
+    fields are preserved under the ``raw`` key so future processing can
+    access them if needed.
+    """
+    data = json.load(file_obj)
+    # Charles exports are similar to HAR.  We try a couple of common
+    # locations where the entries array might live.
+    entries = (
+        data.get("log", {}).get("entries")
+        or data.get("entries")
+        or []
+    )
+
+    events: List[Dict[str, Any]] = []
+    for entry in entries:
+        request = entry.get("request", {})
+        response = entry.get("response", {})
+        event: Dict[str, Any] = {
+            "url": request.get("url"),
+            "method": request.get("method"),
+            "status": response.get("status"),
+            "startedDateTime": entry.get("startedDateTime"),
+            "requestHeaders": {h.get("name"): h.get("value") for h in request.get("headers", [])},
+            "responseHeaders": {h.get("name"): h.get("value") for h in response.get("headers", [])},
+            "postData": request.get("postData"),
+            "queryParams": {p.get("name"): p.get("value") for p in request.get("queryString", [])},
+            "bodyJSON": None,
+            "raw": entry,
+        }
+        post = event.get("postData") or {}
+        text = post.get("text")
+        if isinstance(text, str):
+            try:
+                event["bodyJSON"] = json.loads(text)
+            except json.JSONDecodeError:
+                # leave bodyJSON as None if the payload isn't valid JSON
+                pass
+        events.append(event)
+
+    return events

--- a/backend/server.py
+++ b/backend/server.py
@@ -14,6 +14,9 @@ import shutil
 import glob
 from openpyxl import load_workbook
 
+from .parsers.chlsj_parser import parse_chlsj
+import io
+
 app = FastAPI(title="Harmony QA API", description="QA Testing API for HAR file analysis")
 
 # CORS middleware
@@ -24,6 +27,65 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+def parse_har(file_obj: io.TextIOBase):
+    """Convert a HAR file object into a list of network events.
+
+    The schema matches the output of :func:`parse_chlsj` so the frontend can
+    treat both sources uniformly.  Only a subset of fields is extracted.
+    """
+    data = json.load(file_obj)
+    entries = data.get("log", {}).get("entries", [])
+    events = []
+    for entry in entries:
+        request = entry.get("request", {})
+        response = entry.get("response", {})
+        event = {
+            "url": request.get("url"),
+            "method": request.get("method"),
+            "status": response.get("status"),
+            "startedDateTime": entry.get("startedDateTime"),
+            "requestHeaders": {h.get("name"): h.get("value") for h in request.get("headers", [])},
+            "responseHeaders": {h.get("name"): h.get("value") for h in response.get("headers", [])},
+            "postData": request.get("postData"),
+            "queryParams": {p.get("name"): p.get("value") for p in request.get("queryString", [])},
+            "bodyJSON": None,
+            "raw": entry,
+        }
+        post = event.get("postData") or {}
+        text = post.get("text")
+        if isinstance(text, str):
+            try:
+                event["bodyJSON"] = json.loads(text)
+            except json.JSONDecodeError:
+                pass
+        events.append(event)
+    return events
+
+
+@app.post("/api/ingest")
+async def ingest(file: UploadFile = File(...)):
+    """Ingest a network log in HAR or Charles .chlsj format.
+
+    The response is a simple list of normalized network events that can be
+    further processed by Harmony.  This endpoint is intentionally lightweight
+    and does not perform any Adobe-specific validation."""
+    ext = os.path.splitext(file.filename)[1].lower()
+    contents = await file.read()
+    try:
+        text = contents.decode("utf-8")
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="Unable to decode upload as UTF-8")
+
+    with io.StringIO(text) as f:
+        if ext == ".chlsj":
+            events = parse_chlsj(f)
+        elif ext == ".har":
+            events = parse_har(f)
+        else:
+            raise HTTPException(status_code=400, detail="Unsupported file type")
+    return {"events": events}
 
 # Pydantic models
 class TestCase(BaseModel):


### PR DESCRIPTION
## Summary
- add parser for Charles .chlsj sessions producing normalized network events
- add FastAPI `/api/ingest` endpoint handling HAR and .chlsj uploads

## Testing
- `python -m py_compile backend/parsers/chlsj_parser.py backend/server.py`
- `python - <<'PY'
from backend.server import parse_har
with open('demo.har','r',encoding='utf-8') as f:
    events = parse_har(f)
print(len(events))
print(events[0]['url'] if events else 'no events')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b758a213a4832380ee633baf1e8883