### PR TITLE
Add basic HAR parser

### DIFF
--- a/backend/parsers/har_parser.py
+++ b/backend/parsers/har_parser.py
@@ -1,0 +1,42 @@
+import json
+from typing import List, Dict, Any, IO
+
+
+def parse_har(file_obj: IO) -> List[Dict[str, Any]]:
+    """Parse a HTTP Archive (HAR) file into a list of network events.
+
+    The returned events use the same structure as those produced by
+    :func:`parse_chlsj` so downstream normalization can operate on either
+    format without caring about the original source.  Only a subset of the
+    official HAR specification is handled; unknown fields from each entry are
+    preserved under the ``raw`` key to aid future debugging.
+    """
+    data = json.load(file_obj)
+    entries = data.get("log", {}).get("entries", [])
+
+    events: List[Dict[str, Any]] = []
+    for entry in entries:
+        request = entry.get("request", {})
+        response = entry.get("response", {})
+        event: Dict[str, Any] = {
+            "url": request.get("url"),
+            "method": request.get("method"),
+            "status": response.get("status"),
+            "startedDateTime": entry.get("startedDateTime"),
+            "requestHeaders": {h.get("name"): h.get("value") for h in request.get("headers", [])},
+            "responseHeaders": {h.get("name"): h.get("value") for h in response.get("headers", [])},
+            "postData": request.get("postData"),
+            "queryParams": {p.get("name"): p.get("value") for p in request.get("queryString", [])},
+            "bodyJSON": None,
+            "raw": entry,
+        }
+        post = event.get("postData") or {}
+        text = post.get("text")
+        if isinstance(text, str):
+            try:
+                event["bodyJSON"] = json.loads(text)
+            except json.JSONDecodeError:
+                pass
+        events.append(event)
+
+    return events

--- a/tests/test_har_parser.py
+++ b/tests/test_har_parser.py
@@ -1,0 +1,37 @@
+import io
+import json
+
+from backend.parsers.har_parser import parse_har
+
+
+def test_parse_har_basic():
+    sample = {
+        "log": {
+            "entries": [
+                {
+                    "startedDateTime": "2023-01-01T00:00:00Z",
+                    "request": {
+                        "url": "https://example.com/v1/events",
+                        "method": "POST",
+                        "headers": [{"name": "Content-Type", "value": "application/json"}],
+                        "queryString": [
+                            {"name": "s:event:type", "value": "play"},
+                            {"name": "s:event:sid", "value": "abc123"},
+                            {"name": "l:event:ts", "value": "1712345678901"},
+                            {"name": "l:event:playhead", "value": "12.34"},
+                            {"name": "s:stream:type", "value": "vod"},
+                            {"name": "s:asset:type", "value": "main"}
+                        ],
+                        "postData": {"text": "{\"foo\": \"bar\"}"},
+                    },
+                    "response": {"status": 200, "headers": []},
+                }
+            ]
+        }
+    }
+    events = parse_har(io.StringIO(json.dumps(sample)))
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["url"] == "https://example.com/v1/events"
+    assert ev["queryParams"]["s:event:type"] == "play"
+    assert ev["bodyJSON"] == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- add parser for standard HAR files yielding Harmony NetworkEvent schema
- include unit test for HAR parsing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b76cc2f044832394151e6580f9fa19