### PR TITLE
feat: validate ping cadence

### DIFF
--- a/backend/media/__init__.py
+++ b/backend/media/__init__.py
@@ -4,10 +4,12 @@ from .models import MediaEvent
 from .normalize import network_events_to_media_events
 from .metrics import compute_basic_metrics
 from .state_machine import validate_event_order
+from .timing import validate_ping_cadence
 
 __all__ = [
     "MediaEvent",
     "network_events_to_media_events",
     "compute_basic_metrics",
     "validate_event_order",
+    "validate_ping_cadence",
 ]

--- a/backend/media/timing.py
+++ b/backend/media/timing.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+"""Ping cadence validation helpers.
+
+This module implements a very small portion of the timing engine described in
+*Harmony Heartbeat+*.  It focuses solely on verifying the cadence of ``ping``
+requests during main content and advertisement playback.  The goal is not to be
+feature complete but to provide a lightweight utility that unit tests can
+exercise.
+"""
+
+from typing import Iterable, List
+
+from .models import MediaEvent
+
+
+def validate_ping_cadence(
+    events: Iterable[MediaEvent],
+    main_cadence: float = 10.0,
+    ad_cadence: float = 1.0,
+    tolerance: float = 2.0,
+) -> List[str]:
+    """Validate ping intervals for main content and ad playback.
+
+    Parameters
+    ----------
+    events:
+        Chronologically ordered :class:`MediaEvent` objects belonging to a
+        single session.
+    main_cadence:
+        Expected seconds between pings while main content is playing.
+    ad_cadence:
+        Expected seconds between pings while advertisements are playing.
+    tolerance:
+        Allowed deviation in seconds from the expected cadence.
+
+    Returns
+    -------
+    list of str
+        Human readable violation messages.  The list will be empty when all
+        pings occur within the specified cadence and tolerance.
+    """
+
+    cad_main_ms = int(main_cadence * 1000)
+    cad_ad_ms = int(ad_cadence * 1000)
+    tol_ms = int(tolerance * 1000)
+
+    current_asset: str | None = None  # 'main' or 'ad'
+    expected_ts: int | None = None
+    violations: List[str] = []
+
+    for event in sorted(events, key=lambda e: e.tsDevice):
+        t = event.type
+        asset = event.assetType or event.params.get("s:asset:type")
+
+        if t in {"play", "adStart"}:
+            current_asset = "ad" if (asset == "ad" or t == "adStart") else "main"
+            cadence_ms = cad_ad_ms if current_asset == "ad" else cad_main_ms
+            expected_ts = event.tsDevice + cadence_ms
+            continue
+
+        if t == "ping" and current_asset is not None:
+            cadence_ms = cad_ad_ms if current_asset == "ad" else cad_main_ms
+            if expected_ts is not None:
+                delta = event.tsDevice - expected_ts
+                if abs(delta) > tol_ms:
+                    if delta > 0:
+                        violations.append(
+                            f"missing ping before {event.tsDevice} (expected around {expected_ts})"
+                        )
+                    else:
+                        violations.append(
+                            f"early ping at {event.tsDevice} (expected around {expected_ts})"
+                        )
+            expected_ts = event.tsDevice + cadence_ms
+            continue
+
+        if t in {
+            "pauseStart",
+            "bufferStart",
+            "adBreakStart",
+            "adBreakComplete",
+            "adComplete",
+            "sessionEnd",
+            "sessionComplete",
+        }:
+            current_asset = None
+            expected_ts = None
+            continue
+        # Other event types are ignored.
+
+    return violations
+
+
+__all__ = ["validate_ping_cadence"]

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,33 @@
+from backend.media import MediaEvent, validate_ping_cadence
+
+
+def test_ping_cadence_valid_main_and_ad():
+    events = [
+        MediaEvent(sessionId="1", type="play", tsDevice=0, playhead=0.0, assetType="main"),
+        MediaEvent(sessionId="1", type="ping", tsDevice=10000, playhead=10.0, assetType="main"),
+        MediaEvent(sessionId="1", type="ping", tsDevice=20000, playhead=20.0, assetType="main"),
+        MediaEvent(sessionId="1", type="adStart", tsDevice=30000, playhead=30.0, assetType="ad"),
+        MediaEvent(sessionId="1", type="ping", tsDevice=31000, playhead=31.0, assetType="ad"),
+        MediaEvent(sessionId="1", type="ping", tsDevice=32000, playhead=32.0, assetType="ad"),
+    ]
+    assert validate_ping_cadence(events) == []
+
+
+def test_ping_cadence_missing_main_ping():
+    events = [
+        MediaEvent(sessionId="1", type="play", tsDevice=0, playhead=0.0, assetType="main"),
+        MediaEvent(sessionId="1", type="ping", tsDevice=15000, playhead=15.0, assetType="main"),
+    ]
+    violations = validate_ping_cadence(events)
+    assert violations
+    assert any("missing ping" in v for v in violations)
+
+
+def test_ping_cadence_early_main_ping():
+    events = [
+        MediaEvent(sessionId="1", type="play", tsDevice=0, playhead=0.0, assetType="main"),
+        MediaEvent(sessionId="1", type="ping", tsDevice=1000, playhead=1.0, assetType="main"),
+    ]
+    violations = validate_ping_cadence(events)
+    assert violations
+    assert any("early ping" in v for v in violations)


### PR DESCRIPTION
## Summary
- add timing module with helper to validate ping cadence for main content and ads
- expose validator in media package
- cover ping cadence scenarios with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b770c004d08323a35817a3d37ef8bc