### PR TITLE
Add basic Heartbeat scenario schema

### DIFF
--- a/backend/scenarios/__init__.py
+++ b/backend/scenarios/__init__.py
@@ -1,0 +1,11 @@
+"""Scenario specification models for Harmony Heartbeat+."""
+
+from .schema import Scenario, EventCondition, PingRequirement, ScenarioConstraints, ParamRule
+
+__all__ = [
+    "Scenario",
+    "EventCondition",
+    "PingRequirement",
+    "ScenarioConstraints",
+    "ParamRule",
+]

--- a/backend/scenarios/schema.py
+++ b/backend/scenarios/schema.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Pydantic models describing the Heartbeat scenario DSL.
+
+The real Harmony Heartbeat+ project contains a rich domain specific language
+for expressing validation scenarios.  This module implements a very small
+subset of that language so unit tests can parse and reason about scenarios
+without depending on the full production implementation.
+
+Only a handful of fields from the specification are supported.  Additional
+fields can be added incrementally as the validator evolves.
+"""
+
+from typing import List, Optional, Literal
+from pydantic import BaseModel, Field
+
+
+class PingRequirement(BaseModel):
+    """Cadence and tolerance configuration for ping validation."""
+
+    cadenceSec: float = Field(..., gt=0, description="Expected cadence in seconds")
+    toleranceSec: float = Field(0, ge=0, description="Allowed deviation in seconds")
+    minCount: Optional[int] = Field(
+        None, ge=0, description="Minimum number of pings expected"
+    )
+
+
+class WithinMsOf(BaseModel):
+    """Relative timing constraint used by event conditions."""
+
+    after: Optional[str] = None
+    before: Optional[str] = None
+    lte: Optional[int] = Field(None, ge=0)
+    gte: Optional[int] = Field(None, ge=0)
+
+
+class EventCondition(BaseModel):
+    """Single expected media event within a scenario."""
+
+    type: str
+    after: Optional[str] = None
+    withinMsOf: Optional[WithinMsOf] = None
+    requirePings: Optional[PingRequirement] = None
+
+
+class ScenarioConstraints(BaseModel):
+    """Global constraints applied across the scenario."""
+
+    mainPing: Optional[PingRequirement] = None
+    adPing: Optional[PingRequirement] = None
+    livePlayheadMode: bool = False
+
+
+class ParamRule(BaseModel):
+    """Rules asserting the presence of parameters on events."""
+
+    on: Literal["All"] | str
+    require: List[str] = Field(default_factory=list)
+
+
+class Scenario(BaseModel):
+    """Top level scenario description."""
+
+    name: str
+    streamType: Optional[Literal["vod", "live", "linear"]] = None
+    expect: List[EventCondition] = Field(..., min_length=1)
+    constraints: ScenarioConstraints = Field(default_factory=ScenarioConstraints)
+    paramRules: List[ParamRule] = Field(default_factory=list)
+
+
+__all__ = [
+    "Scenario",
+    "EventCondition",
+    "PingRequirement",
+    "ScenarioConstraints",
+    "ParamRule",
+]

--- a/tests/test_scenario_schema.py
+++ b/tests/test_scenario_schema.py
@@ -1,0 +1,32 @@
+import pytest
+from pydantic import ValidationError
+
+from backend.scenarios import Scenario
+
+
+def test_parse_example_scenario():
+    data = {
+        "name": "VOD with preroll + midroll + pause + buffer",
+        "streamType": "vod",
+        "expect": [
+            {"type": "sessionStart"},
+            {"type": "play", "after": "sessionStart"},
+        ],
+        "constraints": {
+            "mainPing": {"cadenceSec": 10, "toleranceSec": 2},
+            "livePlayheadMode": False,
+        },
+        "paramRules": [
+            {"on": "All", "require": ["s:sc:rsid"]}
+        ],
+    }
+    scenario = Scenario.model_validate(data)
+    assert scenario.name.startswith("VOD")
+    assert scenario.expect[0].type == "sessionStart"
+    assert scenario.constraints.mainPing.cadenceSec == 10
+    assert scenario.paramRules[0].require == ["s:sc:rsid"]
+
+
+def test_expect_required():
+    with pytest.raises(ValidationError):
+        Scenario.model_validate({"name": "missing"})


### PR DESCRIPTION
## Summary
- introduce Pydantic models for Heartbeat scenario DSL
- include test coverage for parsing scenarios and enforcing required fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7720c7d4083239943b761f335e0ed