### PR TITLE
Add media session analyzer utility

### DIFF
--- a/backend/media/__init__.py
+++ b/backend/media/__init__.py
@@ -5,6 +5,7 @@ from .normalize import network_events_to_media_events
 from .metrics import compute_basic_metrics
 from .state_machine import validate_event_order
 from .timing import validate_ping_cadence
+from .analyzer import analyze_session, analyze_network_log
 
 __all__ = [
     "MediaEvent",
@@ -12,4 +13,6 @@ __all__ = [
     "compute_basic_metrics",
     "validate_event_order",
     "validate_ping_cadence",
+    "analyze_session",
+    "analyze_network_log",
 ]

--- a/backend/media/analyzer.py
+++ b/backend/media/analyzer.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""High level helpers for validating Adobe media sessions.
+
+This module ties together the individual components provided by the
+:mod:`backend.media` package – normalization, ordering rules, ping cadence
+checks and basic metric calculations.  It exposes convenience functions that
+accept either already-normalized :class:`MediaEvent` objects or raw network
+log entries.  The functions return a dictionary containing computed metrics and
+any validation violations that were detected.
+
+The implementation is intentionally lightweight; it focuses on the pieces
+implemented in the test suite (event ordering, ping cadence and simple
+metrics).  Additional rules can be layered on later without changing the
+public interface.
+"""
+
+from typing import Iterable, Dict, Any
+
+from .models import MediaEvent
+from .normalize import network_events_to_media_events
+from .state_machine import validate_event_order
+from .timing import validate_ping_cadence
+from .metrics import compute_basic_metrics
+
+
+def analyze_session(events: Iterable[MediaEvent]) -> Dict[str, Any]:
+    """Analyze a sequence of :class:`MediaEvent` objects.
+
+    Parameters
+    ----------
+    events:
+        Chronologically ordered ``MediaEvent`` instances.  The helper sorts the
+        events by ``tsDevice`` to guard against minor ordering mistakes in the
+        input.
+
+    Returns
+    -------
+    dict
+        Mapping with two keys:
+
+        ``metrics``
+            Basic playback duration metrics as returned by
+            :func:`compute_basic_metrics`.
+        ``violations``
+            Dictionary containing lists of human readable violation messages
+            under ``ordering`` and ``timing``.
+    """
+
+    ordered = sorted(events, key=lambda e: e.tsDevice)
+    violations = {
+        "ordering": validate_event_order(ordered),
+        "timing": validate_ping_cadence(ordered),
+    }
+    metrics = compute_basic_metrics(ordered)
+    return {"metrics": metrics, "violations": violations}
+
+
+def analyze_network_log(events: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    """Analyze a raw network log represented as dictionaries.
+
+    This helper first normalizes the network entries using
+    :func:`network_events_to_media_events` before delegating to
+    :func:`analyze_session`.
+    """
+
+    media_events = network_events_to_media_events(events)
+    return analyze_session(media_events)
+
+
+__all__ = ["analyze_session", "analyze_network_log"]

--- a/tests/test_media_analyzer.py
+++ b/tests/test_media_analyzer.py
@@ -1,0 +1,71 @@
+import pytest
+
+from backend.media import MediaEvent, analyze_session, analyze_network_log
+
+
+def make_event(t, ts, asset="main"):
+    return MediaEvent(
+        sessionId="s",
+        type=t,
+        tsDevice=ts,
+        playhead=0.0,
+        streamType="vod",
+        assetType=asset,
+        params={"s:asset:type": asset},
+    )
+
+
+def test_analyze_session_combines_metrics_and_violations():
+    events = [
+        make_event("play", 0, "main"),
+        # missing ping at 10s -> cadence violation
+        make_event("ping", 15000, "main"),
+        # adStart without adBreakStart -> ordering violation
+        make_event("adStart", 20000, "ad"),
+        make_event("adComplete", 22000, "ad"),
+        make_event("sessionEnd", 25000, "main"),
+    ]
+    result = analyze_session(events)
+
+    # Metrics reflect time spent in each asset
+    assert result["metrics"]["content"] == pytest.approx(23.0, rel=1e-3)
+    assert result["metrics"]["ad"] == pytest.approx(2.0, rel=1e-3)
+    assert result["metrics"]["pause"] == 0.0
+    assert result["metrics"]["buffer"] == 0.0
+    assert result["metrics"]["total"] == pytest.approx(25.0, rel=1e-3)
+
+    # Violations from ordering and timing components are surfaced
+    ordering = " ".join(result["violations"]["ordering"])
+    timing = " ".join(result["violations"]["timing"])
+    assert "adStart without" in ordering
+    assert "missing ping" in timing
+
+
+def test_analyze_network_log_normalizes_events():
+    # Minimal network log representing play then ping
+    network_log = [
+        {
+            "bodyJSON": {
+                "s:event:type": "play",
+                "s:event:sid": "s",
+                "l:event:ts": 0,
+                "l:event:playhead": 0,
+                "s:stream:type": "vod",
+                "s:asset:type": "main",
+            }
+        },
+        {
+            "bodyJSON": {
+                "s:event:type": "ping",
+                "s:event:sid": "s",
+                "l:event:ts": 10000,
+                "l:event:playhead": 10,
+                "s:stream:type": "vod",
+                "s:asset:type": "main",
+            }
+        },
+    ]
+    result = analyze_network_log(network_log)
+    assert result["metrics"]["content"] == pytest.approx(10.0, rel=1e-3)
+    assert result["violations"]["ordering"] == []
+    assert result["violations"]["timing"] == []


### PR DESCRIPTION
## Summary
- add `analyze_session` and `analyze_network_log` helpers to compute playback metrics and aggregate ordering/ping cadence violations
- expose analyzer functions in media package API
- test analyzer coverage for MediaEvent sequences and raw network logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7735a333883239deeaa2ab7486caa