### PR TITLE
Add parameter rule validation to Heartbeat analysis

### DIFF
--- a/backend/media/__init__.py
+++ b/backend/media/__init__.py
@@ -5,6 +5,7 @@ from .normalize import network_events_to_media_events
 from .metrics import compute_basic_metrics
 from .state_machine import validate_event_order
 from .timing import validate_ping_cadence
+from .params import validate_param_rules
 from .analyzer import analyze_session, analyze_network_log
 
 __all__ = [
@@ -13,6 +14,7 @@ __all__ = [
     "compute_basic_metrics",
     "validate_event_order",
     "validate_ping_cadence",
+    "validate_param_rules",
     "analyze_session",
     "analyze_network_log",
 ]

--- a/backend/media/params.py
+++ b/backend/media/params.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Parameter validation helpers for media events.
+
+This module implements a lightweight validator that checks whether required
+parameters are present on media events.  It is intentionally small in scope so
+that unit tests can exercise the behaviour without relying on the full Harmony
+Heartbeat+ implementation.
+"""
+
+from typing import Iterable, List
+
+from .models import MediaEvent
+from ..scenarios.schema import ParamRule
+
+
+def validate_param_rules(events: Iterable[MediaEvent], rules: Iterable[ParamRule]) -> List[str]:
+    """Validate parameter presence according to ``rules``.
+
+    Parameters
+    ----------
+    events:
+        Chronologically ordered :class:`MediaEvent` objects.
+    rules:
+        Iterable of :class:`ParamRule` objects describing which parameters must
+        be present on which event types.  The special event type ``"All"``
+        applies the rule to every event.
+
+    Returns
+    -------
+    list of str
+        Human readable violation messages describing any missing parameters.
+    """
+
+    violations: List[str] = []
+    for event in events:
+        for rule in rules:
+            if rule.on != "All" and rule.on != event.type:
+                continue
+            for name in rule.require:
+                value = event.params.get(name)
+                if value in (None, ""):
+                    violations.append(
+                        f"{event.type} missing required parameter {name}"
+                    )
+    return violations
+
+
+__all__ = ["validate_param_rules"]

--- a/tests/test_param_rules.py
+++ b/tests/test_param_rules.py
@@ -1,0 +1,24 @@
+from backend.media import MediaEvent, analyze_session
+from backend.scenarios.schema import ParamRule
+
+
+def make_event(t, ts, params=None):
+    params = params or {}
+    return MediaEvent(
+        sessionId="s",
+        type=t,
+        tsDevice=ts,
+        playhead=0.0,
+        streamType="vod",
+        assetType="main",
+        params=params,
+    )
+
+
+def test_validate_param_rules_flags_missing_params():
+    events = [make_event("play", 0, params={"s:asset:type": "main"})]
+    rules = [ParamRule(on="play", require=["s:asset:type", "l:event:playhead"])]
+    result = analyze_session(events, param_rules=rules)
+    violations = result["violations"]["params"]
+    assert any("l:event:playhead" in v for v in violations)
+    assert not any("s:asset:type" in v for v in violations)


### PR DESCRIPTION
## Summary
- Add `validate_param_rules` helper to check required parameters on media events
- Integrate parameter validation into `analyze_session` and `analyze_network_log`
- Test parameter rule enforcement with new unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b776916c308323a340c62eeff8282c