### PR TITLE
Add ping integrity metric for media sessions

### DIFF
--- a/backend/media/__init__.py
+++ b/backend/media/__init__.py
@@ -4,7 +4,7 @@ from .models import MediaEvent
 from .normalize import network_events_to_media_events
 from .metrics import compute_basic_metrics
 from .state_machine import validate_event_order
-from .timing import validate_ping_cadence
+from .timing import validate_ping_cadence, compute_ping_integrity
 from .params import validate_param_rules
 from .analyzer import analyze_session, analyze_network_log
 
@@ -14,6 +14,7 @@ __all__ = [
     "compute_basic_metrics",
     "validate_event_order",
     "validate_ping_cadence",
+    "compute_ping_integrity",
     "validate_param_rules",
     "analyze_session",
     "analyze_network_log",

--- a/backend/media/analyzer.py
+++ b/backend/media/analyzer.py
@@ -20,7 +20,7 @@ from typing import Iterable, Dict, Any
 from .models import MediaEvent
 from .normalize import network_events_to_media_events
 from .state_machine import validate_event_order
-from .timing import validate_ping_cadence
+from .timing import validate_ping_cadence, compute_ping_integrity
 from .metrics import compute_basic_metrics
 from .params import validate_param_rules
 
@@ -65,6 +65,7 @@ def analyze_session(
         rules = [r if isinstance(r, ParamRule) else ParamRule(**r) for r in param_rules]
         violations["params"] = validate_param_rules(ordered, rules)
     metrics = compute_basic_metrics(ordered)
+    metrics["ping_integrity"] = compute_ping_integrity(ordered)
     return {"metrics": metrics, "violations": violations}
 
 

--- a/tests/test_media_analyzer.py
+++ b/tests/test_media_analyzer.py
@@ -33,6 +33,7 @@ def test_analyze_session_combines_metrics_and_violations():
     assert result["metrics"]["pause"] == 0.0
     assert result["metrics"]["buffer"] == 0.0
     assert result["metrics"]["total"] == pytest.approx(25.0, rel=1e-3)
+    assert result["metrics"]["ping_integrity"] < 100.0
 
     # Violations from ordering and timing components are surfaced
     ordering = " ".join(result["violations"]["ordering"])

--- a/tests/test_ping_integrity.py
+++ b/tests/test_ping_integrity.py
@@ -1,0 +1,42 @@
+import pytest
+
+from backend.media import MediaEvent, compute_ping_integrity
+
+
+def make_event(t, ts):
+    return MediaEvent(
+        sessionId="s",
+        type=t,
+        tsDevice=ts,
+        playhead=0.0,
+        streamType="vod",
+        assetType="main",
+        params={"s:asset:type": "main"},
+    )
+
+
+def test_ping_integrity_perfect_sequence():
+    events = [
+        make_event("play", 0),
+        make_event("ping", 10000),
+        make_event("ping", 20000),
+        make_event("sessionEnd", 25000),
+    ]
+    assert compute_ping_integrity(events) == pytest.approx(100.0, rel=1e-3)
+
+
+def test_ping_integrity_missing_ping():
+    events = [
+        make_event("play", 0),
+        make_event("ping", 20000),
+        make_event("sessionEnd", 25000),
+    ]
+    assert compute_ping_integrity(events) == pytest.approx(50.0, rel=1e-3)
+
+
+def test_ping_integrity_short_session_no_expected_pings():
+    events = [
+        make_event("play", 0),
+        make_event("sessionEnd", 5000),
+    ]
+    assert compute_ping_integrity(events) == 100.0


### PR DESCRIPTION
## Summary
- compute percentage of expected pings that arrive on time
- expose new metric via media analyzer
- cover ping integrity edge cases with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7782cc9e08323b32ab966346f0f9f