### PR TITLE
feat: add unified network log parser

### DIFF
--- a/backend/parsers/__init__.py
+++ b/backend/parsers/__init__.py
@@ -1,0 +1,45 @@
+"""Utility helpers for parsing network logs.
+
+This module exposes convenience wrappers around the individual HAR and
+Charles ``.chlsj`` parsers.  The :func:`parse_network_file` function selects the
+appropriate parser based on a filename's extension so callers only need to
+provide the file object and original name.
+"""
+from __future__ import annotations
+
+import os
+from typing import IO, Any, Dict, List
+
+from .har_parser import parse_har
+from .chlsj_parser import parse_chlsj
+
+
+def parse_network_file(file_obj: IO[str], filename: str) -> List[Dict[str, Any]]:
+    """Parse a network log from ``file_obj``.
+
+    Parameters
+    ----------
+    file_obj:
+        Text IO object positioned at the start of the log contents.
+    filename:
+        Name of the uploaded file.  The extension determines which parser to
+        use.  ``.har`` files are treated as HTTP Archive logs while ``.chlsj``
+        files are interpreted as Charles sessions.
+
+    Returns
+    -------
+    list of dict
+        Network events in the common ``NetworkEvent`` structure used
+        throughout Harmony.
+    """
+
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".har":
+        return parse_har(file_obj)
+    if ext == ".chlsj":
+        return parse_chlsj(file_obj)
+    raise ValueError(f"Unsupported file type: {ext}")
+
+
+__all__ = ["parse_network_file", "parse_har", "parse_chlsj"]
+

--- a/tests/test_parse_network_file.py
+++ b/tests/test_parse_network_file.py
@@ -1,0 +1,38 @@
+import io
+import json
+
+from backend.parsers import parse_network_file
+
+
+def _sample_entry():
+    return {
+        "log": {
+            "entries": [
+                {
+                    "startedDateTime": "2023-01-01T00:00:00Z",
+                    "request": {
+                        "url": "https://example.com/v1/events",
+                        "method": "POST",
+                        "headers": [],
+                        "queryString": [],
+                        "postData": {"text": "{}"},
+                    },
+                    "response": {"status": 200, "headers": []},
+                }
+            ]
+        }
+    }
+
+
+def test_parse_network_file_har():
+    sample = _sample_entry()
+    events = parse_network_file(io.StringIO(json.dumps(sample)), "file.har")
+    assert len(events) == 1
+    assert events[0]["url"] == "https://example.com/v1/events"
+
+
+def test_parse_network_file_chlsj():
+    sample = _sample_entry()
+    events = parse_network_file(io.StringIO(json.dumps(sample)), "file.chlsj")
+    assert len(events) == 1
+    assert events[0]["url"] == "https://example.com/v1/events"


### PR DESCRIPTION
## Summary
- centralize HAR and Charles `.chlsj` parsing behind `parse_network_file`
- simplify ingestion endpoint to auto-select parser based on file extension
- add tests covering parser selection for both formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b779fc50dc8323ab3975033606e756