### PR TITLE
Parse URL query params when queryString omitted

### DIFF
--- a/backend/parsers/har_parser.py
+++ b/backend/parsers/har_parser.py
@@ -1,5 +1,6 @@
 import json
 from typing import List, Dict, Any, IO
+from urllib.parse import urlparse, parse_qsl
 
 
 def parse_har(file_obj: IO) -> List[Dict[str, Any]]:
@@ -23,13 +24,26 @@ def parse_har(file_obj: IO) -> List[Dict[str, Any]]:
             "method": request.get("method"),
             "status": response.get("status"),
             "startedDateTime": entry.get("startedDateTime"),
-            "requestHeaders": {h.get("name"): h.get("value") for h in request.get("headers", [])},
-            "responseHeaders": {h.get("name"): h.get("value") for h in response.get("headers", [])},
+            "requestHeaders": {
+                h.get("name"): h.get("value") for h in request.get("headers", [])
+            },
+            "responseHeaders": {
+                h.get("name"): h.get("value") for h in response.get("headers", [])
+            },
             "postData": request.get("postData"),
-            "queryParams": {p.get("name"): p.get("value") for p in request.get("queryString", [])},
+            "queryParams": {
+                p.get("name"): p.get("value") for p in request.get("queryString", [])
+            },
             "bodyJSON": None,
             "raw": entry,
         }
+
+        # Fallback to parsing query parameters from the URL when the HAR entry
+        # does not provide a ``queryString`` array.  Some tools omit the array
+        # entirely which would otherwise leave ``queryParams`` empty.
+        if not event["queryParams"] and isinstance(event["url"], str):
+            parsed = urlparse(event["url"])
+            event["queryParams"] = dict(parse_qsl(parsed.query))
         post = event.get("postData") or {}
         text = post.get("text")
         if isinstance(text, str):

--- a/tests/test_chlsj_parser.py
+++ b/tests/test_chlsj_parser.py
@@ -35,3 +35,22 @@ def test_parse_chlsj_basic():
     assert ev["url"] == "https://example.com/v1/events"
     assert ev["queryParams"]["s:event:type"] == "play"
     assert ev["bodyJSON"] == {"foo": "bar"}
+
+
+def test_parse_chlsj_query_from_url():
+    sample = {
+        "log": {
+            "entries": [
+                {
+                    "startedDateTime": "2023-01-01T00:00:00Z",
+                    "request": {
+                        "url": "https://example.com/v1/events?alpha=1&beta=two",
+                        "method": "GET",
+                    },
+                    "response": {"status": 200, "headers": []},
+                }
+            ]
+        }
+    }
+    events = parse_chlsj(io.StringIO(json.dumps(sample)))
+    assert events[0]["queryParams"] == {"alpha": "1", "beta": "two"}

--- a/tests/test_har_parser.py
+++ b/tests/test_har_parser.py
@@ -35,3 +35,22 @@ def test_parse_har_basic():
     assert ev["url"] == "https://example.com/v1/events"
     assert ev["queryParams"]["s:event:type"] == "play"
     assert ev["bodyJSON"] == {"foo": "bar"}
+
+
+def test_parse_har_query_from_url():
+    sample = {
+        "log": {
+            "entries": [
+                {
+                    "startedDateTime": "2023-01-01T00:00:00Z",
+                    "request": {
+                        "url": "https://example.com/v1/events?alpha=1&beta=two",
+                        "method": "GET",
+                    },
+                    "response": {"status": 200, "headers": []},
+                }
+            ]
+        }
+    }
+    events = parse_har(io.StringIO(json.dumps(sample)))
+    assert events[0]["queryParams"] == {"alpha": "1", "beta": "two"}


### PR DESCRIPTION
## Summary
- fallback to parse query parameters from request URL in `.chlsj` and HAR parsers when the `queryString` array is absent
- add unit tests covering URL-based query parsing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b77d01c9248323a5fd4831b84b530b