### PR TITLE
Improve pause and buffer state validation

### DIFF
--- a/backend/media/state_machine.py
+++ b/backend/media/state_machine.py
@@ -72,10 +72,14 @@ def validate_event_order(events: Iterable[MediaEvent]) -> List[str]:
             continue
 
         if t == "pauseStart":
+            if state == _PlaybackState.PAUSED:
+                violations.append("pauseStart while already paused")
             state = _PlaybackState.PAUSED
             continue
 
         if t == "bufferStart":
+            if state == _PlaybackState.BUFFERING:
+                violations.append("bufferStart while already buffering")
             state = _PlaybackState.BUFFERING
             continue
 
@@ -125,6 +129,10 @@ def validate_event_order(events: Iterable[MediaEvent]) -> List[str]:
             if ad_break_active:
                 violations.append("session ended during active ad break")
                 ad_break_active = False
+            if state == _PlaybackState.PAUSED:
+                violations.append("session ended during pause")
+            if state == _PlaybackState.BUFFERING:
+                violations.append("session ended during buffer")
             state = _PlaybackState.IDLE
             continue
 
@@ -134,6 +142,10 @@ def validate_event_order(events: Iterable[MediaEvent]) -> List[str]:
         violations.append("ad not closed with adComplete")
     if ad_break_active:
         violations.append("ad break not closed with adBreakComplete")
+    if state == _PlaybackState.PAUSED:
+        violations.append("pause not closed with play")
+    if state == _PlaybackState.BUFFERING:
+        violations.append("buffer not closed with play")
 
     return violations
 

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -58,3 +58,37 @@ def test_play_while_already_playing():
     ]
     violations = validate_event_order(events)
     assert any("play while already playing" in v for v in violations)
+
+
+def test_pause_not_resumed():
+    events = [
+        make_event("sessionStart", 0),
+        make_event("play", 1000),
+        make_event("pauseStart", 2000),
+        make_event("sessionComplete", 3000),
+    ]
+    violations = validate_event_order(events)
+    assert any("pause" in v for v in violations)
+
+
+def test_buffer_not_resumed():
+    events = [
+        make_event("sessionStart", 0),
+        make_event("play", 1000),
+        make_event("bufferStart", 2000),
+        make_event("sessionComplete", 3000),
+    ]
+    violations = validate_event_order(events)
+    assert any("buffer" in v for v in violations)
+
+
+def test_duplicate_pause_start():
+    events = [
+        make_event("sessionStart", 0),
+        make_event("play", 1000),
+        make_event("pauseStart", 2000),
+        make_event("pauseStart", 2500),
+        make_event("play", 3000),
+    ]
+    violations = validate_event_order(events)
+    assert any("pauseStart while already paused" in v for v in violations)


### PR DESCRIPTION
## Summary
- flag duplicate pauseStart and bufferStart events
- detect sessions ending or missing play after pause/buffer
- cover pause/buffer cases with new unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ccb3ac688323b0fe65e63be66a2f