### PR TITLE
Handle Charles .chls session files

### DIFF
--- a/backend/parsers/__init__.py
+++ b/backend/parsers/__init__.py
@@ -12,19 +12,21 @@ from typing import IO, Any, Dict, List
 
 from .har_parser import parse_har
 from .chlsj_parser import parse_chlsj
+from .chls_parser import parse_chls
 
 
-def parse_network_file(file_obj: IO[str], filename: str) -> List[Dict[str, Any]]:
+def parse_network_file(file_obj: IO[Any], filename: str) -> List[Dict[str, Any]]:
     """Parse a network log from ``file_obj``.
 
     Parameters
     ----------
     file_obj:
-        Text IO object positioned at the start of the log contents.
+        IO object positioned at the start of the log contents.
     filename:
         Name of the uploaded file.  The extension determines which parser to
         use.  ``.har`` files are treated as HTTP Archive logs while ``.chlsj``
-        files are interpreted as Charles sessions.
+        files are interpreted as Charles sessions.  The binary ``.chls`` format
+        is converted using the Charles CLI when available.
 
     Returns
     -------
@@ -38,8 +40,10 @@ def parse_network_file(file_obj: IO[str], filename: str) -> List[Dict[str, Any]]
         return parse_har(file_obj)
     if ext == ".chlsj":
         return parse_chlsj(file_obj)
+    if ext == ".chls":
+        return parse_chls(file_obj)
     raise ValueError(f"Unsupported file type: {ext}")
 
 
-__all__ = ["parse_network_file", "parse_har", "parse_chlsj"]
+__all__ = ["parse_network_file", "parse_har", "parse_chlsj", "parse_chls"]
 

--- a/backend/parsers/chls_parser.py
+++ b/backend/parsers/chls_parser.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import BinaryIO, Dict, List
+
+from .har_parser import parse_har
+
+
+def parse_chls(file_obj: BinaryIO) -> List[Dict[str, object]]:
+    """Parse a Charles ``.chls`` session file.
+
+    The binary ``.chls`` format must be converted to HAR or ``.chlsj`` using the
+    Charles CLI.  This function attempts the conversion and then delegates to the
+    HAR parser.  If the ``charles`` command is unavailable a ``RuntimeError`` is
+    raised instructing the caller to supply a ``.har`` or ``.chlsj`` file
+    instead.
+    """
+    charles = shutil.which("charles")
+    if charles is None:
+        raise RuntimeError(
+            "Charles CLI ('charles') not found. Provide a .har or .chlsj file instead."
+        )
+
+    with tempfile.NamedTemporaryFile(suffix=".chls", delete=False) as src:
+        src.write(file_obj.read())
+        src_path = src.name
+    with tempfile.NamedTemporaryFile(suffix=".har", delete=False) as dst:
+        dst_path = dst.name
+
+    try:
+        subprocess.run([charles, "convert", src_path, dst_path], check=True, capture_output=True)
+        with open(dst_path, "r", encoding="utf-8") as converted:
+            return parse_har(converted)
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode("utf-8", errors="ignore") if e.stderr else ""
+        raise RuntimeError(
+            f"Failed to convert .chls using Charles CLI: {stderr.strip()}"
+        ) from e
+    finally:
+        for path in (src_path, dst_path):
+            try:
+                os.remove(path)
+            except OSError:
+                pass

--- a/tests/test_parse_network_file.py
+++ b/tests/test_parse_network_file.py
@@ -36,3 +36,15 @@ def test_parse_network_file_chlsj():
     events = parse_network_file(io.StringIO(json.dumps(sample)), "file.chlsj")
     assert len(events) == 1
     assert events[0]["url"] == "https://example.com/v1/events"
+
+
+def test_parse_network_file_chls_no_charles(tmp_path):
+    path = tmp_path / "file.chls"
+    path.write_bytes(b"not-a-real-chls")
+    with open(path, "rb") as f:
+        try:
+            parse_network_file(f, str(path))
+        except RuntimeError as e:
+            assert "Charles CLI" in str(e)
+        else:
+            raise AssertionError("RuntimeError expected when Charles CLI missing")


### PR DESCRIPTION
## Summary
- allow ingestion of binary Charles `.chls` sessions by converting through the `charles` CLI
- route `.chls` files through new parser in `parse_network_file`
- test `.chls` handling when the `charles` CLI is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87e1905c48323b6931febcebcd3b6