### PR TITLE
feat: sniff network log type

### DIFF
--- a/backend/parsers/__init__.py
+++ b/backend/parsers/__init__.py
@@ -1,12 +1,14 @@
 """Utility helpers for parsing network logs.
 
 This module exposes convenience wrappers around the individual HAR and
-Charles ``.chlsj`` parsers.  The :func:`parse_network_file` function selects the
-appropriate parser based on a filename's extension so callers only need to
-provide the file object and original name.
+Charles ``.chlsj`` parsers.  The :func:`parse_network_file` function attempts to
+select an appropriate parser based on a filename's extension or, when the
+extension is unknown, by sniffing the file contents.
 """
 from __future__ import annotations
 
+import io
+import json
 import os
 from typing import IO, Any, Dict, List
 
@@ -15,7 +17,13 @@ from .chlsj_parser import parse_chlsj
 from .chls_parser import parse_chls
 
 
-def parse_network_file(file_obj: IO[Any], filename: str) -> List[Dict[str, Any]]:
+def _looks_like_json(text: str) -> bool:
+    """Return True if ``text`` appears to be JSON."""
+
+    return text.lstrip().startswith("{") or text.lstrip().startswith("[")
+
+
+def parse_network_file(file_obj: IO[Any], filename: str | None = None) -> List[Dict[str, Any]]:
     """Parse a network log from ``file_obj``.
 
     Parameters
@@ -23,10 +31,9 @@ def parse_network_file(file_obj: IO[Any], filename: str) -> List[Dict[str, Any]]
     file_obj:
         IO object positioned at the start of the log contents.
     filename:
-        Name of the uploaded file.  The extension determines which parser to
-        use.  ``.har`` files are treated as HTTP Archive logs while ``.chlsj``
-        files are interpreted as Charles sessions.  The binary ``.chls`` format
-        is converted using the Charles CLI when available.
+        Optional name of the uploaded file.  The extension helps determine which
+        parser to use but is not strictly required when the content can be
+        sniffed.
 
     Returns
     -------
@@ -35,13 +42,50 @@ def parse_network_file(file_obj: IO[Any], filename: str) -> List[Dict[str, Any]]
         throughout Harmony.
     """
 
-    ext = os.path.splitext(filename)[1].lower()
+    ext = os.path.splitext(filename or "")[1].lower()
     if ext == ".har":
         return parse_har(file_obj)
     if ext == ".chlsj":
         return parse_chlsj(file_obj)
     if ext == ".chls":
         return parse_chls(file_obj)
+
+    # Extension unknown – attempt to sniff the contents.  Read the full payload
+    # into memory so it can be wrapped in the appropriate IO type for the
+    # underlying parser functions.
+    content = file_obj.read()
+    if isinstance(content, bytes):
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            # Binary data that isn't valid UTF-8 is assumed to be a Charles
+            # ``.chls`` session.  ``parse_chls`` will raise a helpful error if
+            # the CLI is unavailable.
+            return parse_chls(io.BytesIO(content))
+    else:
+        text = content
+
+    if _looks_like_json(text):
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Unsupported file content: invalid JSON") from exc
+
+        # ``.har`` files store entries under ``log.entries`` while ``.chlsj``
+        # exports may place them at the top level or under ``log``.
+        if isinstance(data, dict) and isinstance(data.get("log"), dict) and isinstance(
+            data["log"].get("entries"), list
+        ):
+            return parse_har(io.StringIO(text))
+        if isinstance(data, dict) and isinstance(data.get("entries"), list):
+            return parse_chlsj(io.StringIO(text))
+        # Fallback to the HAR parser for any other JSON structure – it will
+        # surface a meaningful error if the shape is incompatible.
+        return parse_har(io.StringIO(text))
+
+    # Non-JSON text is treated as a binary Charles session.
+    if isinstance(content, bytes):
+        return parse_chls(io.BytesIO(content))
     raise ValueError(f"Unsupported file type: {ext}")
 
 

--- a/tests/test_parse_network_file.py
+++ b/tests/test_parse_network_file.py
@@ -48,3 +48,22 @@ def test_parse_network_file_chls_no_charles(tmp_path):
             assert "Charles CLI" in str(e)
         else:
             raise AssertionError("RuntimeError expected when Charles CLI missing")
+
+
+def test_sniff_har_without_extension():
+    sample = _sample_entry()
+    events = parse_network_file(io.StringIO(json.dumps(sample)), "noext")
+    assert len(events) == 1
+    assert events[0]["url"] == "https://example.com/v1/events"
+
+
+def test_sniff_binary_defaults_to_chls(tmp_path):
+    path = tmp_path / "capture"  # no extension
+    path.write_bytes(b"\x00\x01binary")
+    with open(path, "rb") as f:
+        try:
+            parse_network_file(f, str(path))
+        except RuntimeError as e:
+            assert "Charles CLI" in str(e)
+        else:
+            raise AssertionError("RuntimeError expected when Charles CLI missing")


### PR DESCRIPTION
## Summary
- sniff network log content to choose HAR, CHLSJ, or CHLS parser when extension is missing or unknown
- add tests for sniffing JSON and binary logs without extensions

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87ff2125c8323947a59af27126423