### PR TITLE
Add source tracking and body decompression to network parsers

### DIFF
--- a/backend/parsers/__init__.py
+++ b/backend/parsers/__init__.py
@@ -44,11 +44,11 @@ def parse_network_file(file_obj: IO[Any], filename: str | None = None) -> List[D
 
     ext = os.path.splitext(filename or "")[1].lower()
     if ext == ".har":
-        return parse_har(file_obj)
+        return parse_har(file_obj, filename)
     if ext == ".chlsj":
-        return parse_chlsj(file_obj)
+        return parse_chlsj(file_obj, filename)
     if ext == ".chls":
-        return parse_chls(file_obj)
+        return parse_chls(file_obj, filename)
 
     # Extension unknown – attempt to sniff the contents.  Read the full payload
     # into memory so it can be wrapped in the appropriate IO type for the
@@ -61,7 +61,7 @@ def parse_network_file(file_obj: IO[Any], filename: str | None = None) -> List[D
             # Binary data that isn't valid UTF-8 is assumed to be a Charles
             # ``.chls`` session.  ``parse_chls`` will raise a helpful error if
             # the CLI is unavailable.
-            return parse_chls(io.BytesIO(content))
+            return parse_chls(io.BytesIO(content), filename)
     else:
         text = content
 
@@ -76,16 +76,16 @@ def parse_network_file(file_obj: IO[Any], filename: str | None = None) -> List[D
         if isinstance(data, dict) and isinstance(data.get("log"), dict) and isinstance(
             data["log"].get("entries"), list
         ):
-            return parse_har(io.StringIO(text))
+            return parse_har(io.StringIO(text), filename)
         if isinstance(data, dict) and isinstance(data.get("entries"), list):
-            return parse_chlsj(io.StringIO(text))
+            return parse_chlsj(io.StringIO(text), filename)
         # Fallback to the HAR parser for any other JSON structure – it will
         # surface a meaningful error if the shape is incompatible.
-        return parse_har(io.StringIO(text))
+        return parse_har(io.StringIO(text), filename)
 
     # Non-JSON text is treated as a binary Charles session.
     if isinstance(content, bytes):
-        return parse_chls(io.BytesIO(content))
+        return parse_chls(io.BytesIO(content), filename)
     raise ValueError(f"Unsupported file type: {ext}")
 
 

--- a/backend/parsers/chls_parser.py
+++ b/backend/parsers/chls_parser.py
@@ -2,12 +2,12 @@ import os
 import shutil
 import subprocess
 import tempfile
-from typing import BinaryIO, Dict, List
+from typing import BinaryIO, Dict, List, Optional
 
 from .har_parser import parse_har
 
 
-def parse_chls(file_obj: BinaryIO) -> List[Dict[str, object]]:
+def parse_chls(file_obj: BinaryIO, source_name: Optional[str] = None) -> List[Dict[str, object]]:
     """Parse a Charles ``.chls`` session file.
 
     The binary ``.chls`` format must be converted to HAR or ``.chlsj`` using the
@@ -31,7 +31,7 @@ def parse_chls(file_obj: BinaryIO) -> List[Dict[str, object]]:
     try:
         subprocess.run([charles, "convert", src_path, dst_path], check=True, capture_output=True)
         with open(dst_path, "r", encoding="utf-8") as converted:
-            return parse_har(converted)
+            return parse_har(converted, source_name)
     except subprocess.CalledProcessError as e:
         stderr = e.stderr.decode("utf-8", errors="ignore") if e.stderr else ""
         raise RuntimeError(

--- a/backend/parsers/utils.py
+++ b/backend/parsers/utils.py
@@ -1,0 +1,40 @@
+import base64
+import gzip
+import zlib
+from typing import Optional
+
+try:
+    import brotli  # type: ignore
+except Exception:  # pragma: no cover - brotli is optional
+    brotli = None
+
+def decode_body(text: str, content_encoding: Optional[str], is_base64: bool) -> str:
+    """Decode an HTTP message body.
+
+    Parameters
+    ----------
+    text:
+        The body payload. May be plain text or base64 encoded.
+    content_encoding:
+        Value of the ``Content-Encoding`` header. Supported values are
+        ``gzip``, ``deflate`` and ``br``.
+    is_base64:
+        ``True`` if ``text`` is base64 encoded.
+
+    Returns
+    -------
+    str
+        The decoded body as a UTF-8 string. Errors are replaced during
+        decoding to avoid hard failures when the payload is not valid UTF-8.
+    """
+    data = base64.b64decode(text) if is_base64 else text.encode("utf-8")
+    encoding = (content_encoding or "").lower()
+    if encoding == "gzip":
+        data = gzip.decompress(data)
+    elif encoding == "deflate":
+        data = zlib.decompress(data)
+    elif encoding in ("br", "brotli"):
+        if brotli is None:
+            raise RuntimeError("brotli package is required for brotli decoding")
+        data = brotli.decompress(data)
+    return data.decode("utf-8", errors="replace")

--- a/tests/test_chlsj_parser.py
+++ b/tests/test_chlsj_parser.py
@@ -2,6 +2,8 @@ import io
 import json
 
 from backend.parsers.chlsj_parser import parse_chlsj
+import base64
+import gzip
 
 
 def test_parse_chlsj_basic():
@@ -29,12 +31,13 @@ def test_parse_chlsj_basic():
             ]
         }
     }
-    events = parse_chlsj(io.StringIO(json.dumps(sample)))
+    events = parse_chlsj(io.StringIO(json.dumps(sample)), "sample.chlsj")
     assert len(events) == 1
     ev = events[0]
     assert ev["url"] == "https://example.com/v1/events"
     assert ev["queryParams"]["s:event:type"] == "play"
     assert ev["bodyJSON"] == {"foo": "bar"}
+    assert ev["source"] == {"file": "sample.chlsj", "index": 0}
 
 
 def test_parse_chlsj_query_from_url():
@@ -52,5 +55,28 @@ def test_parse_chlsj_query_from_url():
             ]
         }
     }
-    events = parse_chlsj(io.StringIO(json.dumps(sample)))
+    events = parse_chlsj(io.StringIO(json.dumps(sample)), "sample.chlsj")
     assert events[0]["queryParams"] == {"alpha": "1", "beta": "two"}
+
+
+def test_parse_chlsj_decompress_body():
+    body = json.dumps({"foo": "bar"}).encode("utf-8")
+    encoded = base64.b64encode(gzip.compress(body)).decode("ascii")
+    sample = {
+        "log": {
+            "entries": [
+                {
+                    "startedDateTime": "2023-01-01T00:00:00Z",
+                    "request": {
+                        "url": "https://example.com/v1/events",
+                        "method": "POST",
+                        "headers": [{"name": "Content-Encoding", "value": "gzip"}],
+                        "postData": {"text": encoded, "encoding": "base64"},
+                    },
+                    "response": {"status": 200, "headers": []},
+                }
+            ]
+        }
+    }
+    events = parse_chlsj(io.StringIO(json.dumps(sample)), "sample.chlsj")
+    assert events[0]["bodyJSON"] == {"foo": "bar"}

--- a/tests/test_parse_network_file.py
+++ b/tests/test_parse_network_file.py
@@ -29,6 +29,7 @@ def test_parse_network_file_har():
     events = parse_network_file(io.StringIO(json.dumps(sample)), "file.har")
     assert len(events) == 1
     assert events[0]["url"] == "https://example.com/v1/events"
+    assert events[0]["source"] == {"file": "file.har", "index": 0}
 
 
 def test_parse_network_file_chlsj():
@@ -36,6 +37,7 @@ def test_parse_network_file_chlsj():
     events = parse_network_file(io.StringIO(json.dumps(sample)), "file.chlsj")
     assert len(events) == 1
     assert events[0]["url"] == "https://example.com/v1/events"
+    assert events[0]["source"] == {"file": "file.chlsj", "index": 0}
 
 
 def test_parse_network_file_chls_no_charles(tmp_path):


### PR DESCRIPTION
## Summary
- track originating file and index for each parsed network event
- support gzip/deflate/brotli body decoding with new helper
- update tests to cover source pointers and compressed bodies

## Testing
- `PYTHONPATH=. pytest tests/test_har_parser.py tests/test_chlsj_parser.py tests/test_parse_network_file.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8825020fc8323b210460e717aad34