### PR TITLE
Add basic request fingerprinting heuristics

### DIFF
--- a/backend/fingerprint.py
+++ b/backend/fingerprint.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Heuristics for inferring vendor and transport details from requests.
+
+The helpers in this module perform lightweight fingerprinting of network
+requests to guess which analytics ecosystem produced them.  The goal is to
+attach high level metadata to each parsed request so later processing stages
+can route them through the appropriate normalization and validation logic.
+
+Only a handful of common Adobe and Google Analytics routes are recognized.  The
+logic is intentionally conservative and returns ``None`` for any attribute that
+cannot be confidently determined.
+"""
+
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+
+def fingerprint_event(event: Dict[str, object]) -> Dict[str, Optional[str]]:
+    """Return analytics metadata for a single network ``event``.
+
+    Parameters
+    ----------
+    event:
+        Network event dictionary produced by :mod:`backend.parsers`.  Only the
+        ``url`` field is required; other fields are ignored.
+
+    Returns
+    -------
+    dict
+        Mapping with ``vendor``, ``transport`` and ``profile`` keys.  Values may
+        be ``None`` when the request could not be classified.
+    """
+
+    url = str(event.get("url") or "")
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    path = parsed.path.lower()
+
+    vendor: Optional[str] = None
+    transport: Optional[str] = None
+    profile: Optional[str] = None
+
+    # --- Adobe Analytics and Media ---
+    if host.endswith("hb-api.omtrdc.net") or host.endswith("hb.omtrdc.net"):
+        vendor = "adobe"
+        transport = "heartbeat"
+        profile = "legacy"
+    elif host.endswith("adobedc.net") and "/ee/v1/" in path:
+        vendor = "adobe"
+        transport = "edge"
+        profile = "web"
+    elif "/b/ss/" in path:
+        vendor = "adobe"
+        transport = "aa_classic"
+        profile = "web"
+
+    # --- Google Analytics 4 ---
+    elif "google-analytics.com" in host or "googletagmanager.com" in host:
+        vendor = "ga4"
+        transport = "measurement"
+        profile = "web"
+
+    return {"vendor": vendor, "transport": transport, "profile": profile}
+
+
+__all__ = ["fingerprint_event"]

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,41 @@
+from backend.fingerprint import fingerprint_event
+
+
+def test_fingerprint_adobe_edge():
+    event = {"url": "https://example.adobedc.net/ee/v1/interact"}
+    fp = fingerprint_event(event)
+    assert fp["vendor"] == "adobe"
+    assert fp["transport"] == "edge"
+    assert fp["profile"] == "web"
+
+
+def test_fingerprint_adobe_heartbeat():
+    event = {"url": "https://metrics.hb-api.omtrdc.net/x"}
+    fp = fingerprint_event(event)
+    assert fp["vendor"] == "adobe"
+    assert fp["transport"] == "heartbeat"
+    assert fp["profile"] == "legacy"
+
+
+def test_fingerprint_aa_classic():
+    event = {"url": "https://example.sc.omtrdc.net/b/ss/rsid/0"}
+    fp = fingerprint_event(event)
+    assert fp["vendor"] == "adobe"
+    assert fp["transport"] == "aa_classic"
+    assert fp["profile"] == "web"
+
+
+def test_fingerprint_ga4():
+    event = {"url": "https://www.google-analytics.com/g/collect?v=2"}
+    fp = fingerprint_event(event)
+    assert fp["vendor"] == "ga4"
+    assert fp["transport"] == "measurement"
+    assert fp["profile"] == "web"
+
+
+def test_fingerprint_unknown():
+    event = {"url": "https://example.com/"}
+    fp = fingerprint_event(event)
+    assert fp["vendor"] is None
+    assert fp["transport"] is None
+    assert fp["profile"] is None


### PR DESCRIPTION
## Summary
- add fingerprint_event to classify network requests by vendor and transport
- test Adobe Edge, Heartbeat, AA classic, GA4 and unknown hosts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b88360fb188323963486b750f69bdc