### PR TITLE
Add unified request model with fingerprint metadata

### DIFF
--- a/backend/unified.py
+++ b/backend/unified.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Helpers for normalizing parsed network events."""
+
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field
+
+from .fingerprint import fingerprint_event
+
+
+class UnifiedRequest(BaseModel):
+    """Normalized representation of a single network request.
+
+    The model captures common attributes shared across the various parsers
+    and attaches high level analytics metadata inferred by
+    :func:`fingerprint_event`.  It forms the foundation for further vendor
+    specific normalization steps.
+    """
+
+    ts_wall: Optional[str] = Field(None, description="Wall clock timestamp")
+    url: Optional[str] = Field(None, description="Full request URL")
+    host: Optional[str] = Field(None, description="Request host name")
+    path: Optional[str] = Field(None, description="Request path")
+    query: Dict[str, Any] = Field(default_factory=dict, description="Query parameters")
+    method: Optional[str] = Field(None, description="HTTP method")
+    status: Optional[int] = Field(None, description="HTTP status code")
+    requestHeaders: Dict[str, Any] = Field(default_factory=dict, description="Request headers")
+    responseHeaders: Dict[str, Any] = Field(default_factory=dict, description="Response headers")
+    body: Any = Field(None, description="Parsed body payload")
+    vendor: Optional[str] = Field(None, description="Detected analytics vendor")
+    transport: Optional[str] = Field(None, description="Detected transport mechanism")
+    profile: Optional[str] = Field(None, description="Detected profile/platform")
+    source: Dict[str, Any] = Field(default_factory=dict, description="Origin of the request")
+
+
+def to_unified_requests(events: List[Dict[str, Any]]) -> List[UnifiedRequest]:
+    """Convert parsed network ``events`` into :class:`UnifiedRequest` objects."""
+
+    unified: List[UnifiedRequest] = []
+    for event in events:
+        parsed = urlparse(str(event.get("url") or ""))
+        meta = fingerprint_event(event)
+        unified.append(
+            UnifiedRequest(
+                ts_wall=event.get("startedDateTime"),
+                url=event.get("url"),
+                host=parsed.netloc or None,
+                path=parsed.path or None,
+                query=event.get("queryParams") or {},
+                method=event.get("method"),
+                status=event.get("status"),
+                requestHeaders=event.get("requestHeaders") or {},
+                responseHeaders=event.get("responseHeaders") or {},
+                body=event.get("bodyJSON"),
+                vendor=meta.get("vendor"),
+                transport=meta.get("transport"),
+                profile=meta.get("profile"),
+                source=event.get("source") or {},
+            )
+        )
+    return unified
+
+
+__all__ = ["UnifiedRequest", "to_unified_requests"]

--- a/tests/test_unified.py
+++ b/tests/test_unified.py
@@ -1,0 +1,37 @@
+from backend.unified import to_unified_requests, UnifiedRequest
+
+
+def make_event(url: str) -> dict:
+    return {
+        "url": url,
+        "method": "GET",
+        "status": 200,
+        "startedDateTime": "2024-01-01T00:00:00Z",
+        "requestHeaders": {},
+        "responseHeaders": {},
+        "queryParams": {},
+        "bodyJSON": {},
+        "source": {"file": "test.har", "index": 0},
+    }
+
+
+def test_unified_request_fingerprint_and_parts():
+    events = [make_event("https://example.adobedc.net/ee/v1/collect?x=1")]
+    unified = to_unified_requests(events)
+    assert len(unified) == 1
+    req = unified[0]
+    assert isinstance(req, UnifiedRequest)
+    assert req.host == "example.adobedc.net"
+    assert req.path == "/ee/v1/collect"
+    assert req.vendor == "adobe"
+    assert req.transport == "edge"
+    assert req.profile == "web"
+    assert req.source["file"] == "test.har"
+
+
+def test_unified_request_unknown_vendor():
+    events = [make_event("https://example.com/path")]
+    req = to_unified_requests(events)[0]
+    assert req.vendor is None
+    assert req.transport is None
+    assert req.profile is None


### PR DESCRIPTION
## Summary
- introduce `UnifiedRequest` pydantic model to hold normalized request data
- add `to_unified_requests` utility to convert parser output and attach fingerprint details
- cover unified request behavior with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b886a20f608323831df1c6a46abb6b