### PR TITLE
Add high-level ingest helpers for network logs

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,1 +1,5 @@
 """Harmony backend package."""
+
+from .ingest import ingest_file, ingest_path
+
+__all__ = ["ingest_file", "ingest_path"]

--- a/backend/ingest.py
+++ b/backend/ingest.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""High level ingestion helpers.
+
+This module provides convenience functions that tie together the network
+parsers and the :class:`~backend.unified.UnifiedRequest` model.  The helpers
+accept either an open file object or a filesystem path, automatically detect
+the log format (HAR, ``.chlsj`` or ``.chls``) and return a list of
+:class:`UnifiedRequest` instances ready for further analysis.
+"""
+
+from typing import IO, Any, List
+
+from .parsers import parse_network_file
+from .unified import UnifiedRequest, to_unified_requests
+
+
+def ingest_file(file_obj: IO[Any], filename: str | None = None) -> List[UnifiedRequest]:
+    """Read a network log from ``file_obj`` and return unified requests.
+
+    Parameters
+    ----------
+    file_obj:
+        File-like object positioned at the beginning of a network capture.
+    filename:
+        Optional filename used for format detection and traceability.
+
+    Returns
+    -------
+    list of :class:`UnifiedRequest`
+        Normalised request objects produced from the network log.
+    """
+
+    events = parse_network_file(file_obj, filename)
+    return to_unified_requests(events)
+
+
+def ingest_path(path: str) -> List[UnifiedRequest]:
+    """Read a network log from ``path`` and return unified requests."""
+
+    # Open in binary mode so the underlying parser can decide how to decode
+    # the contents (text vs binary ``.chls`` sessions).
+    with open(path, "rb") as fh:
+        return ingest_file(fh, path)
+
+
+__all__ = ["ingest_file", "ingest_path"]

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,39 @@
+import io
+import json
+from backend.ingest import ingest_file
+
+
+def _sample_entry():
+    return {
+        "log": {
+            "entries": [
+                {
+                    "startedDateTime": "2023-01-01T00:00:00Z",
+                    "request": {
+                        "url": "https://example.com/v1/events",
+                        "method": "GET",
+                        "headers": [],
+                        "queryString": [],
+                    },
+                    "response": {"status": 200, "headers": []},
+                }
+            ]
+        }
+    }
+
+
+def test_ingest_file_har():
+    sample = _sample_entry()
+    reqs = ingest_file(io.StringIO(json.dumps(sample)), "file.har")
+    assert len(reqs) == 1
+    req = reqs[0]
+    assert req.url == "https://example.com/v1/events"
+    assert req.source == {"file": "file.har", "index": 0}
+
+
+def test_ingest_file_chlsj():
+    sample = _sample_entry()
+    reqs = ingest_file(io.StringIO(json.dumps(sample)), "file.chlsj")
+    assert len(reqs) == 1
+    assert reqs[0].url == "https://example.com/v1/events"
+    assert reqs[0].source["file"] == "file.chlsj"


### PR DESCRIPTION
## Summary
- add `ingest_file`/`ingest_path` utilities to parse network captures into `UnifiedRequest`
- expose ingest helpers from backend package
- cover ingestion with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8936274d88323b14fc7bae2d4ff1f