### PR TITLE
feat: detect client platform

### DIFF
--- a/backend/unified.py
+++ b/backend/unified.py
@@ -32,6 +32,7 @@ class UnifiedRequest(BaseModel):
     vendor: Optional[str] = Field(None, description="Detected analytics vendor")
     transport: Optional[str] = Field(None, description="Detected transport mechanism")
     profile: Optional[str] = Field(None, description="Detected profile/platform")
+    platform: Optional[str] = Field(None, description="Detected client platform")
     source: Dict[str, Any] = Field(default_factory=dict, description="Origin of the request")
 
 
@@ -57,6 +58,7 @@ def to_unified_requests(events: List[Dict[str, Any]]) -> List[UnifiedRequest]:
                 vendor=meta.get("vendor"),
                 transport=meta.get("transport"),
                 profile=meta.get("profile"),
+                platform=meta.get("platform"),
                 source=event.get("source") or {},
             )
         )

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -7,6 +7,7 @@ def test_fingerprint_adobe_edge():
     assert fp["vendor"] == "adobe"
     assert fp["transport"] == "edge"
     assert fp["profile"] == "web"
+    assert fp["platform"] is None
 
 
 def test_fingerprint_adobe_heartbeat():
@@ -15,6 +16,7 @@ def test_fingerprint_adobe_heartbeat():
     assert fp["vendor"] == "adobe"
     assert fp["transport"] == "heartbeat"
     assert fp["profile"] == "legacy"
+    assert fp["platform"] is None
 
 
 def test_fingerprint_aa_classic():
@@ -23,6 +25,7 @@ def test_fingerprint_aa_classic():
     assert fp["vendor"] == "adobe"
     assert fp["transport"] == "aa_classic"
     assert fp["profile"] == "web"
+    assert fp["platform"] is None
 
 
 def test_fingerprint_ga4():
@@ -31,6 +34,7 @@ def test_fingerprint_ga4():
     assert fp["vendor"] == "ga4"
     assert fp["transport"] == "measurement"
     assert fp["profile"] == "web"
+    assert fp["platform"] is None
 
 
 def test_fingerprint_unknown():
@@ -39,3 +43,22 @@ def test_fingerprint_unknown():
     assert fp["vendor"] is None
     assert fp["transport"] is None
     assert fp["profile"] is None
+    assert fp["platform"] is None
+
+
+def test_fingerprint_platform_from_user_agent():
+    event = {
+        "url": "https://example.adobedc.net/ee/v1/interact",
+        "requestHeaders": {
+            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)"
+        },
+    }
+    fp = fingerprint_event(event)
+    assert fp["platform"] == "ios"
+
+    event = {
+        "url": "https://example.adobedc.net/ee/v1/interact",
+        "requestHeaders": {"User-Agent": "Roku/DVP-9.10 (519.10E04111A)"},
+    }
+    fp = fingerprint_event(event)
+    assert fp["platform"] == "roku"

--- a/tests/test_unified.py
+++ b/tests/test_unified.py
@@ -26,6 +26,7 @@ def test_unified_request_fingerprint_and_parts():
     assert req.vendor == "adobe"
     assert req.transport == "edge"
     assert req.profile == "web"
+    assert req.platform is None
     assert req.source["file"] == "test.har"
 
 
@@ -35,3 +36,13 @@ def test_unified_request_unknown_vendor():
     assert req.vendor is None
     assert req.transport is None
     assert req.profile is None
+    assert req.platform is None
+
+
+def test_unified_request_with_platform():
+    event = make_event("https://example.adobedc.net/ee/v1/collect?x=1")
+    event["requestHeaders"] = {
+        "User-Agent": "Mozilla/5.0 (Linux; Android 11; Pixel 5)"
+    }
+    req = to_unified_requests([event])[0]
+    assert req.platform == "android"


### PR DESCRIPTION
## Summary
- infer client platform from User-Agent strings
- expose platform on UnifiedRequest objects
- test platform detection for fingerprinting and unified requests

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8944c48408323b4398287c51edd67