### PR TITLE
feat: detect SDK version in request fingerprinting

### DIFF
--- a/backend/unified.py
+++ b/backend/unified.py
@@ -33,6 +33,9 @@ class UnifiedRequest(BaseModel):
     transport: Optional[str] = Field(None, description="Detected transport mechanism")
     profile: Optional[str] = Field(None, description="Detected profile/platform")
     platform: Optional[str] = Field(None, description="Detected client platform")
+    sdk_version: Optional[str] = Field(
+        None, description="Detected client SDK version"
+    )
     source: Dict[str, Any] = Field(default_factory=dict, description="Origin of the request")
 
 
@@ -59,6 +62,7 @@ def to_unified_requests(events: List[Dict[str, Any]]) -> List[UnifiedRequest]:
                 transport=meta.get("transport"),
                 profile=meta.get("profile"),
                 platform=meta.get("platform"),
+                sdk_version=meta.get("sdk_version"),
                 source=event.get("source") or {},
             )
         )

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -62,3 +62,21 @@ def test_fingerprint_platform_from_user_agent():
     }
     fp = fingerprint_event(event)
     assert fp["platform"] == "roku"
+
+
+def test_fingerprint_sdk_version_from_query_and_body():
+    # Query parameter extraction
+    event = {
+        "url": "https://metrics.hb-api.omtrdc.net/x",
+        "queryParams": {"s:ver": "3.0.1"},
+    }
+    fp = fingerprint_event(event)
+    assert fp["sdk_version"] == "3.0.1"
+
+    # Nested body field extraction (Adobe Edge style)
+    event = {
+        "url": "https://example.adobedc.net/ee/v1/interact",
+        "bodyJSON": {"xdm": {"implementationDetails": {"version": "2.4.0"}}},
+    }
+    fp = fingerprint_event(event)
+    assert fp["sdk_version"] == "2.4.0"

--- a/tests/test_unified.py
+++ b/tests/test_unified.py
@@ -46,3 +46,10 @@ def test_unified_request_with_platform():
     }
     req = to_unified_requests([event])[0]
     assert req.platform == "android"
+
+
+def test_unified_request_sdk_version():
+    event = make_event("https://metrics.hb-api.omtrdc.net/x")
+    event["queryParams"] = {"s:ver": "4.2.0"}
+    req = to_unified_requests([event])[0]
+    assert req.sdk_version == "4.2.0"


### PR DESCRIPTION
## Summary
- capture SDK version from query params or body
- expose sdk_version on UnifiedRequest
- add tests for version extraction

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b894f04ad883238da3b44b192a3ac8