### PR TITLE
feat: analyze arbitrary network logs

### DIFF
--- a/backend/adobe.py
+++ b/backend/adobe.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Adobe-specific helpers."""
+
+from typing import Dict, Any, List
+from urllib.parse import urlparse
+
+
+def extract_rsid(event: Dict[str, Any]) -> List[str]:
+    """Return report suite IDs present on an analytics ``event``.
+
+    The helper looks for RSIDs in the classic `/b/ss/<rsid>/` path as well as
+    in the `rsid` or `rsid_list` query parameters.  Duplicate values are
+    removed and the resulting list is sorted for stable summaries.
+    """
+
+    rsids: List[str] = []
+    url = str(event.get("url") or "")
+    parsed = urlparse(url)
+    path = parsed.path.lower()
+    if "/b/ss/" in path:
+        segment = path.split("/b/ss/", 1)[1]
+        parts = segment.split("/", 1)[0]
+        rsids.extend([r.strip() for r in parts.split(",") if r.strip()])
+
+    params = event.get("queryParams") or {}
+    rsid_param = params.get("rsid")
+    if isinstance(rsid_param, str) and rsid_param:
+        rsids.append(rsid_param.strip())
+    rsid_list = params.get("rsid_list")
+    if isinstance(rsid_list, str) and rsid_list:
+        rsids.extend([r.strip() for r in rsid_list.split(",") if r.strip()])
+
+    # Return unique, sorted list
+    return sorted(set(rsids))
+
+
+__all__ = ["extract_rsid"]

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import './App.css';
 import TestCaseManager from './components/TestCaseManager';
 import TestGroupManager from './components/TestGroupManager';
-import HarAnalyzer from './components/HarAnalyzer';
+import LogAnalyzer from './components/LogAnalyzer';
 import ResultsDashboard from './components/ResultsDashboard';
 import { FileText, Upload, BarChart3, Settings, Layers } from 'lucide-react';
 import { BACKEND_URL } from './config';
@@ -17,7 +17,7 @@ const App = () => {
   const tabs = [
     { id: 'test-cases', label: 'TEST CASES', icon: Settings },
     { id: 'test-groups', label: 'TEST GROUPS', icon: Layers },
-    { id: 'analyzer', label: 'HAR ANALYZER', icon: Upload },
+    { id: 'analyzer', label: 'LOG ANALYZER', icon: Upload },
     { id: 'results', label: 'RESULTS', icon: BarChart3 }
   ];
 
@@ -59,7 +59,7 @@ const App = () => {
       case 'test-groups':
         return <TestGroupManager testGroups={testGroups} testCases={testCases} onGroupsUpdate={fetchTestGroups} />;
       case 'analyzer':
-        return <HarAnalyzer onAnalysisComplete={handleAnalysisComplete} />;
+        return <LogAnalyzer onAnalysisComplete={handleAnalysisComplete} />;
       case 'results':
         return <ResultsDashboard report={analysisReport} />;
       default:
@@ -111,7 +111,7 @@ const App = () => {
 
       <footer className="app-footer">
         <div className="footer-content">
-          <span>HARMONY QA v1.0 | HTTP ARCHIVE ANALYSIS SYSTEM</span>
+          <span>HARMONY QA v1.0 | NETWORK LOG ANALYSIS SYSTEM</span>
           <span>{new Date().toISOString().split('T')[0]} {new Date().toTimeString().split(' ')[0]}</span>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- add `/api/analyze-media` for session-based heartbeat validation
- list `.har`, `.chls`, and `.chlsj` via `/api/log-files` and analyze by name
- surface RSID counts from AA hits
- update UI to accept Charles logs and use new endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b89796be148323bd94a3640f65762e