### PR TITLE
chore: generalize ui text for network logs

### DIFF
--- a/frontend/src/components/LogAnalyzer.js
+++ b/frontend/src/components/LogAnalyzer.js
@@ -149,7 +149,7 @@ const LogAnalyzer = ({ onAnalysisComplete }) => {
           </div>
           <div className="card-body">
             <div
-              className="har-files-grid"
+              className="log-files-grid"
               style={{
                 display: 'grid',
                 gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
@@ -160,7 +160,7 @@ const LogAnalyzer = ({ onAnalysisComplete }) => {
               {availableLogFiles.map((logFile, index) => (
                 <div
                   key={index}
-                  className={`har-file-card ${
+                  className={`log-file-card ${
                     selectedLogFile?.filename === logFile.filename ? 'selected' : ''
                   }`}
                   style={{

--- a/frontend/src/components/ResultsDashboard.js
+++ b/frontend/src/components/ResultsDashboard.js
@@ -26,7 +26,7 @@ const ResultsDashboard = ({ report }) => {
           <div className="card-body text-center">
             <AlertCircle size={48} style={{ margin: '20px 0' }} />
             <h3>NO ANALYSIS DATA AVAILABLE</h3>
-            <p>UPLOAD AND ANALYZE A HAR FILE TO VIEW RESULTS</p>
+            <p>UPLOAD AND ANALYZE A NETWORK LOG TO VIEW RESULTS</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- generalize available-log file UI labels to avoid HAR-only naming
- clarify Results Dashboard copy that any network log can be analyzed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8992be3c08323b23361353c18b2ca