### PR TITLE
Improve frontend handling for backend proxy errors

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -30,6 +30,10 @@ const App = () => {
   const fetchTestCases = async () => {
     try {
       const response = await fetch(`${BACKEND_URL}/api/test-cases`);
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `Request failed with status ${response.status}`);
+      }
       const data = await response.json();
       setTestCases(data.test_cases || []);
     } catch (error) {
@@ -40,6 +44,10 @@ const App = () => {
   const fetchTestGroups = async () => {
     try {
       const response = await fetch(`${BACKEND_URL}/api/test-groups`);
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `Request failed with status ${response.status}`);
+      }
       const data = await response.json();
       setTestGroups(data.test_groups || []);
     } catch (error) {

--- a/frontend/src/components/LogAnalyzer.js
+++ b/frontend/src/components/LogAnalyzer.js
@@ -18,10 +18,15 @@ const LogAnalyzer = ({ onAnalysisComplete }) => {
   const fetchAvailableLogFiles = async () => {
     try {
       const response = await fetch(`${BACKEND_URL}/api/log-files`);
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `Request failed with status ${response.status}`);
+      }
       const data = await response.json();
       setAvailableLogFiles(data.log_files || []);
     } catch (error) {
       console.error('Error fetching available log files:', error);
+      setMessage('ERROR: ' + error.message);
     }
   };
 
@@ -94,7 +99,13 @@ const LogAnalyzer = ({ onAnalysisComplete }) => {
         });
       }
 
-      const data = await response.json();
+      const text = await response.text();
+      let data;
+      try {
+        data = JSON.parse(text);
+      } catch {
+        throw new Error(text || 'Invalid response from server');
+      }
 
       if (response.ok) {
         setMessage('ANALYSIS COMPLETED SUCCESSFULLY');


### PR DESCRIPTION
## Summary
- Guard frontend fetches against non-JSON proxy responses
- Surface proxy failures in the log analyzer instead of JSON parse errors

## Testing
- `pytest`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b89d7ec7cc832380ee09b87811bdad